### PR TITLE
Fix missing library path in live555

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ module = Extension('live555',
                    include_dirs=['%s/%s/include' % (INSTALL_DIR, x) for x in ['liveMedia', 'BasicUsageEnvironment', 'UsageEnvironment', 'groupsock']],
                    libraries=['liveMedia', 'groupsock', 'BasicUsageEnvironment', 'UsageEnvironment'],
                    #extra_compile_args = ['-fPIC'],
-                   library_dirs=['%s/%s' % (INSTALL_DIR, x) for x in ['liveMedia', 'UsageEnvironment', 'groupsock']],
+                   library_dirs=['%s/%s' % (INSTALL_DIR, x) for x in ['liveMedia', 'UsageEnvironment', 'BasicUsageEnvironment','groupsock']],
                    sources = ['module.cpp'])
   
 setup(name = 'live555',


### PR DESCRIPTION
setup was not providing the library path to BasicUsageEnvironment
